### PR TITLE
La lista de elecciones se muestra de forma correcta

### DIFF
--- a/static/scripts/elections/election_list.js
+++ b/static/scripts/elections/election_list.js
@@ -3,18 +3,17 @@ var ElectionList = function() {
     self.elections = ko.observableArray();
     self.currentPage = ko.observable(0);
     self.canLoadMore = ko.observable(false);
-    self.noResults = ko.observable(false);
+    self.isLoading = ko.observable(false);
 
     self.getElections = function() {
+        self.isLoading(true);
         $.get('/elections/list', {
             page: self.currentPage()
         }).done(function(response){
+            self.isLoading(false);
             if(response['elections'].length > 0) {
                 self.elections(response['elections']);
                 self.canLoadMore(self.elections().length == 20);
-            }
-            else {
-                self.noResults = true;
             }
         });
     }

--- a/templates/elections/index.html
+++ b/templates/elections/index.html
@@ -15,11 +15,11 @@
             <h2>Votaciones vigentes<p><small>Votaciones en las cuales usted puede participar.</small></p></h2>
         </div>
 
-        <div class="alert alert-info text-center" data-bind="css: { hidden: elections().length > 0 }">
+        <div class="alert alert-info text-center" data-bind="visible: isLoading">
             Cargando lista de resultados...
         </div>
 
-        <div class="list-group hidden" data-bind="css: { hidden: elections().length == 0 && !noResults() }">
+        <div class="list-group hidden" data-bind="visible: !isLoading">
             <!-- ko foreach: {data: elections, as: 'election'} -->
                 <div class="list-group-item">
                     <h4 class="list-group-item-heading">
@@ -45,7 +45,7 @@
             </button>
         </div>
 
-        <div class="alert alert-danger hidden" data-bind="css: { hidden: !noResults() }">
+        <div class="alert alert-danger hidden" data-bind="visible: !isLoading && elections().length == 0">
             <strong>No hay votaciones en las cuales usted pueda participar.</strong>
         </div>
     </div>

--- a/templates/elections/index.html
+++ b/templates/elections/index.html
@@ -19,7 +19,7 @@
             Cargando lista de resultados...
         </div>
 
-        <div class="list-group hidden" data-bind="visible: !isLoading">
+        <div class="list-group" data-bind="visible: !isLoading">
             <!-- ko foreach: {data: elections, as: 'election'} -->
                 <div class="list-group-item">
                     <h4 class="list-group-item-heading">
@@ -45,7 +45,7 @@
             </button>
         </div>
 
-        <div class="alert alert-danger hidden" data-bind="visible: !isLoading && elections().length == 0">
+        <div class="alert alert-danger" data-bind="visible: !isLoading && elections().length == 0">
             <strong>No hay votaciones en las cuales usted pueda participar.</strong>
         </div>
     </div>


### PR DESCRIPTION
Se evita que la página quede en constante estado de carga cuando no existen elecciones disponibles.
